### PR TITLE
Added public RNG API with range validation, entropy extraction, and state mutation safeguards.

### DIFF
--- a/contracts/StackRand.clar
+++ b/contracts/StackRand.clar
@@ -67,3 +67,92 @@
   )
 )
 
+
+;; Get a byte from a buffer at specified index
+(define-private (get-byte-at (buff (buff 32)) (index uint))
+  (default-to 0x00 (element-at buff index))
+)
+
+;; Extract number from buffer
+(define-private (extract-uint-from-buff (random-buff (buff 32)))
+  (let 
+    (
+      (byte-0 (buff-to-uint (get-byte-at random-buff u0)))
+      (byte-1 (buff-to-uint (get-byte-at random-buff u1)))
+      (byte-2 (buff-to-uint (get-byte-at random-buff u2)))
+      (byte-3 (buff-to-uint (get-byte-at random-buff u3)))
+      (byte-4 (buff-to-uint (get-byte-at random-buff u4)))
+      (byte-5 (buff-to-uint (get-byte-at random-buff u5)))
+      (byte-6 (buff-to-uint (get-byte-at random-buff u6)))
+      (byte-7 (buff-to-uint (get-byte-at random-buff u7)))
+    )
+    (+ byte-0 
+      (+ (* byte-1 u256) 
+        (+ (* byte-2 u65536) 
+          (+ (* byte-3 u16777216) 
+            (+ (* byte-4 u4294967296) 
+              (+ (* byte-5 u1099511627776) 
+                (+ (* byte-6 u281474976710656) 
+                  (* byte-7 u72057594037927936))))))))
+  )
+)
+
+
+
+;; Convert buffer byte to uint
+(define-private (buff-to-uint (byte (buff 1)))
+  (unwrap-panic (index-of 0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff byte))
+)
+
+;; Public functions
+
+;; Get a random uint value between 0 and max-value (inclusive)
+(define-public (get-random (user-seed (buff 32)) (max-value uint))
+  (begin
+    ;; Verify the range is valid
+    (asserts! (> max-value u0) ERR_ZERO_RANGE)
+
+    ;; Prevent same-block attacks
+    (asserts! (> stacks-block-height (var-get last-block-height)) ERR_SAME_BLOCK)
+    (var-set last-block-height stacks-block-height)
+
+    ;; Generate raw random value
+    (let 
+      (
+        (raw-random (combine-entropy user-seed))
+        (random-uint (extract-uint-from-buff raw-random))
+        (scaled-random (mod random-uint (+ max-value u1)))
+      )
+
+      ;; Update state for future randomness
+      (var-set nonce (+ (var-get nonce) u1))
+      (var-set entropy-accumulator (sha256 (concat (var-get entropy-accumulator) raw-random)))
+
+      ;; Return the scaled random value
+      (ok scaled-random)
+    )
+  )
+)
+
+;; Get a random value within a specific range (min-value to max-value, inclusive)
+(define-public (get-random-in-range (user-seed (buff 32)) (min-value uint) (max-value uint))
+  (begin
+    ;; Verify the range is valid
+    (asserts! (>= max-value min-value) ERR_INVALID_RANGE)
+
+    ;; Get random value from 0 to (max-value - min-value)
+    (let 
+      (
+        (range (- max-value min-value))
+        (random-result (unwrap-panic (get-random user-seed range)))
+      )
+      ;; Adjust to the required range by adding min-value
+      (ok (+ min-value random-result))
+    )
+  )
+)
+
+;; Get the current entropy accumulator state (for verification)
+(define-read-only (get-entropy-state)
+  (var-get entropy-accumulator)
+)


### PR DESCRIPTION

##  Pull Request Description – *Add Random Number Extraction and Range-Based API to Secure RNG*

---

### 📋 Summary

This PR finalizes the functionality of the **Secure RNG** smart contract by implementing public functions to expose random number generation to end users. It includes logic for both bounded and range-based randomness, conversion helpers for buffer-to-uint extraction, and state mutation to ensure evolving entropy across invocations.

---

### 🔑 Key Additions

#### 🧮 Public Functions

1. **`get-random`**

   * Accepts a user-provided 32-byte seed and a `max-value`
   * Returns a verifiably random number between `0` and `max-value` (inclusive)
   * Enforces **one-call-per-block** rule using `last-block-height` guard
   * Updates internal `entropy-accumulator` and `nonce` for next call

2. **`get-random-in-range`**

   * Accepts `min-value`, `max-value`, and a `user-seed`
   * Internally uses `get-random` to generate a value in `[0, max - min]` and shifts it up by `min`
   * Returns a number between `min-value` and `max-value` (inclusive)

3. **`get-entropy-state`**

   * A read-only view into the `entropy-accumulator` for debugging, auditing, or simulation verification

---

### 🔧 Helper Functions

* **`extract-uint-from-buff`**:

  * Extracts an 8-byte (64-bit) unsigned integer from a 32-byte buffer
  * Reads bytes 0 through 7 using `get-byte-at` and reconstructs the final `uint` value

* **`buff-to-uint`**:

  * Maps a 1-byte buffer to its integer equivalent (0–255) using a fixed lookup table

* **`get-byte-at`**:

  * Defensive wrapper around `element-at` that defaults to `0x00` if the index is out of bounds

---

### 🛡️ Safeguards

* **Same-Block Prevention**:

  * `get-random` fails with `ERR_SAME_BLOCK` if called more than once in the same Stacks block

* **Range Validation**:

  * `get-random` fails with `ERR_ZERO_RANGE` if `max-value` is 0
  * `get-random-in-range` fails with `ERR_INVALID_RANGE` if `min-value > max-value`

* **Entropy Mutability**:

  * Ensures every call mutates internal contract state using hash chaining to strengthen randomness over time

---

### 📁 Contract Structure Summary

* 🗃️ **State Variables**:

  * `entropy-accumulator`: evolving hash of past entropy inputs
  * `last-block-height`: used to prevent same-block execution
  * `nonce`: increases with every request to add uniqueness

* 🔐 **Security Considerations**:

  * User-supplied `buff 32` seed required to prevent deterministic abuse
  * Uses recent block headers, sender, burn block, and nonce for entropy

---
